### PR TITLE
缺省值支持包含冒号

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func getVariableKey(source string) (key, value string) {
 	if strings.Contains(k, ":") {
 		re := strings.Split(k, ":")
 		if len(re) > 1 {
-			return re[0], re[1]
+			return re[0], strings.Join(re[1:], ":")
 		}
 		return re[0], ""
 	}

--- a/main.go
+++ b/main.go
@@ -171,9 +171,9 @@ func getVariableKey(source string) (key, value string) {
 	right := strings.Index(source, "}")
 	k := source[left+1 : right]
 	if strings.Contains(k, ":") {
-		re := strings.Split(k, ":")
+		re := strings.SplitN(k, ":", 2)
 		if len(re) > 1 {
-			return re[0], strings.Join(re[1:], ":")
+			return re[0], re[1]
 		}
 		return re[0], ""
 	}


### PR DESCRIPTION
原有逻辑中，缺省值包含冒号时，缺省值会被截断，例如 `DB_PASSWORD=${DB_PASSWORD:Pass:1234}`  ，含义为缺省为 `Pass:1234`,但由于包含冒号，会被截断，导致缺省值不正确